### PR TITLE
Add processes_size and workers_size to the global stats

### DIFF
--- a/lib/sidekiq/statsd/server_middleware.rb
+++ b/lib/sidekiq/statsd/server_middleware.rb
@@ -39,6 +39,10 @@ module Sidekiq::Statsd
       # All-time counts
       statsd.gauge(prefix('processed'), @sidekiq_stats.processed)
       statsd.gauge(prefix('failed'), @sidekiq_stats.failed)
+
+      # General status
+      statsd.gauge(prefix('processes_size'), @sidekiq_stats.processes_size)
+      statsd.gauge(prefix('workers_size'), @sidekiq_stats.workers_size)
     end
 
     def prefix(*args)


### PR DESCRIPTION
Hi.

We want to be able to raise an alert if we loose one or multiple processes, so we added `processes_size` stat and `workers_size` stat collection.

Cheers !